### PR TITLE
+ fixed nullptr dereference when a single file is opened, not a project

### DIFF
--- a/waka_plugin.cpp
+++ b/waka_plugin.cpp
@@ -214,7 +214,8 @@ void WakaPlugin::trySendHeartbeat(const QString &entry, bool isSaving = false)
 
     heartbeat["entity"] = _lastEntry = entry;
     heartbeat["time"] = _lastTime = curr_time;
-    heartbeat["project"] = ProjectExplorer::ProjectTree::currentProject()->displayName();
+    if (const auto &project = ProjectExplorer::ProjectTree::currentProject())
+        heartbeat["project"] = project->displayName();
     heartbeat["is_write"] = isSaving;
     heartbeat["is_debugging"] = _wakaOptions->isDebug();
     heartbeat["exclude"] = _ignore_patern;


### PR DESCRIPTION
Fixed a crash when opening a single file via QtCreator.