### PR TITLE
[Dev] Use QProcess and Make heartbeat flush

### DIFF
--- a/cligetter.cpp
+++ b/cligetter.cpp
@@ -49,8 +49,20 @@ void CliGetter::startHearBeat(const QString file){
             +" --entity "+file;
     //run the hearbeat here
     emit promptMessage("Command: "+_wakaCliExecutablePath);
-    int x = system(cmd.toStdString().c_str());
-    Q_UNUSED(x);
+    QStringList cmdOptionsList;
+    cmdOptionsList.append("--plugin --plugin QtCreator-wakatime/"+
+                          QString(WAKATIME_PLUGIN_VERSION));
+    cmdOptionsList.append(" --entity "+file);
+    QProcess *process = new QProcess(this);
+    process->start(cmd,cmdOptionsList);
+    connect(process,&QProcess::errorOccurred,
+            [](QProcess::ProcessError error){
+        qDebug()<<"ERROR: "<<error<<"\n";
+    });
+    connect(process,&QProcess::started, [](){
+        qDebug()<<"EXECUTED SUCCESS YEAH!!!"<<"\n";
+    });
+    process->waitForFinished(500000000);
 }
 
 void CliGetter::startUnzipping(QString location){

--- a/cligetter.cpp
+++ b/cligetter.cpp
@@ -50,11 +50,15 @@ void CliGetter::startHearBeat(const QString file){
     //run the hearbeat here
     emit promptMessage("Command: "+_wakaCliExecutablePath);
     QStringList cmdOptionsList;
-    cmdOptionsList.append("--plugin --plugin QtCreator-wakatime/"+
-                          QString(WAKATIME_PLUGIN_VERSION));
-    cmdOptionsList.append(" --entity "+file);
+    cmdOptionsList.append("--plugin");
+    cmdOptionsList.append("QtCreator-wakatime/"+QString(WAKATIME_PLUGIN_VERSION));
+    cmdOptionsList.append("--entity");
+    cmdOptionsList.append(file);
     QProcess *process = new QProcess(this);
-    process->start(cmd,cmdOptionsList);
+    process->setArguments(cmdOptionsList);
+    process->setProgram(_wakaCliExecutablePath);
+    process->start();
+    qDebug()<<"CMD: "<<process->program()<<" args: "<<process->arguments();
     connect(process,&QProcess::errorOccurred,
             [](QProcess::ProcessError error){
         qDebug()<<"ERROR: "<<error<<"\n";

--- a/waka_plugin.cpp
+++ b/waka_plugin.cpp
@@ -118,6 +118,7 @@ bool WakaPlugin::initialize(const QStringList &arguments, QString *errorString)
 
 void WakaPlugin::onDoneSettingUpCLI(){
 
+    //!TODO
     //check if is latest version
     //check if user has asked for updated version
     //if so, then try update the version of wakatime-cli
@@ -196,7 +197,6 @@ void WakaPlugin::onEditorChanged(Core::IEditor *editor)
 
 void WakaPlugin::onAboutToSave(Core::IDocument *document)
 {
-    //emit signal for sending here.
     emit sendHeartBeat(document->filePath().toString());
 }
 

--- a/waka_plugin.h
+++ b/waka_plugin.h
@@ -72,7 +72,7 @@ private:
 
     QString _ignore_patern;
     QThread *_cliGettingThread;
-    QPointer<QToolButton> _heartBeatButton;
+    QSharedPointer<QToolButton> _heartBeatButton;
     QSharedPointer<WakaOptions> _wakaOptions;
     QSharedPointer<WakaOptionsPage> _page;
 };


### PR DESCRIPTION
-Use QProcess instead of system() to avoid showing cmd.exe on windows.
- Make the heartbeat icon flash, like old version used to.